### PR TITLE
Add functions for project affiliations and institution memberships

### DIFF
--- a/iam/pgiam.py
+++ b/iam/pgiam.py
@@ -597,6 +597,95 @@ class Db(object):
         q = "select institution_groups('{0}')".format(institution)
         return self.exec_sql(q, session_identity=session_identity, session=session)[0][0]
 
+    def institution_member_add(
+        self,
+        institution: str,
+        member: str,
+        session_identity: Optional[str] = None,
+        session: Optional[sqlalchemy.orm.session.Session] = None,
+    ) -> dict:
+        """
+        Add a new member to an institution. A new member can be
+        identified by either:
+
+        1) person_id
+        2) user_name
+        3) group (person group, user group, or generic group)
+
+        If a new member is identified using #1, then pg-iam
+        will find their person group, and add it as a member.
+        If #2 is used, then pg-iam will find the user group and
+        add it as a member. In case #3, if a person or user group
+        is given, then it is functionally equivalent to #1 and #2.
+        When a generic group is provided, then the group becomes
+        a member of another group (along with its members, transitively).
+
+        Note: internally, pg-iam adds persons to institutions via their
+        person group, and users to institutions via their user groups.
+
+        Parameters
+        ----------
+        institution: str, the institution to which the member should be added
+        member: str, the new member
+
+        Returns
+        -------
+        dict
+
+        """
+        q = "select institution_member_add('{0}', '{1}')".format(institution, member)
+        return self.exec_sql(q, session_identity=session_identity, session=session)[0][0]
+
+    def institution_member_remove(
+        self,
+        institution: str,
+        member: str,
+        session_identity: Optional[str] = None,
+        session: Optional[sqlalchemy.orm.session.Session] = None,
+    ) -> dict:
+        """
+        Remove a member from an institution. A member can be identified
+        by either:
+
+        1) person_id
+        2) user_name
+        3) group (person group, user group, or generic group)
+
+        Parameters
+        ----------
+        institution: str, the institution from which the member should be
+            removed
+        group_name: str, the existing member to remove
+
+        Returns
+        -------
+        dict
+
+        """
+        q = "select institution_member_remove('{0}', '{1}')".format(institution, member)
+        return self.exec_sql(q, session_identity=session_identity, session=session)[0][0]
+
+    def institution_members(
+        self,
+        institution: str,
+        session_identity: Optional[str] = None,
+        session: Optional[sqlalchemy.orm.session.Session] = None,
+    ) -> dict:
+        """
+        Get the membership graph of institution.
+
+        Parameters
+        ----------
+        institution: str
+
+        Returns
+        -------
+        dict
+
+        """
+        q = "select institution_members('{0}')".format(institution)
+        return self.exec_sql(q, session_identity=session_identity, session=session)[0][0]
+
     def project_group_add(
         self,
         project: str,

--- a/iam/pgiam.py
+++ b/iam/pgiam.py
@@ -530,9 +530,6 @@ class Db(object):
         1) institution_name
         2) institution_group
 
-        Note: internally, pg-iam adds groups to institutions via their
-        institution group.
-
         Parameters
         ----------
         institution: str, the institution to which the group should be

--- a/iam/pgiam.py
+++ b/iam/pgiam.py
@@ -530,7 +530,7 @@ class Db(object):
         1) institution_name
         2) institution_group
 
-        Note: internally, pg-iam adds instituitions to groups via their
+        Note: internally, pg-iam adds groups to institutions via their
         institution group.
 
         Parameters
@@ -595,6 +595,87 @@ class Db(object):
 
         """
         q = "select institution_groups('{0}')".format(institution)
+        return self.exec_sql(q, session_identity=session_identity, session=session)[0][0]
+
+    def project_group_add(
+        self,
+        project: str,
+        group_name: str,
+        session_identity: Optional[str] = None,
+        session: Optional[sqlalchemy.orm.session.Session] = None,
+    ) -> dict:
+        """
+        Affiliate a group to project. A project can be identified
+        by either:
+
+        1) project_number
+        2) project_group
+
+        Note: internally, pg-iam adds groups to projects via their
+        project group.
+
+        Parameters
+        ----------
+        project: str, the project to which the group should be
+            affiliated
+        group_name: str, the new affiliated group
+
+        Returns
+        -------
+        dict
+
+        """
+        q = "select project_group_add('{0}', '{1}')".format(project, group_name)
+        return self.exec_sql(q, session_identity=session_identity, session=session)[0][0]
+
+    def project_group_remove(
+        self,
+        project: str,
+        group_name: str,
+        session_identity: Optional[str] = None,
+        session: Optional[sqlalchemy.orm.session.Session] = None,
+    ) -> dict:
+        """
+        Remove affilitation between a group and a project. A group
+        can be identified by either:
+
+        1) person_id
+        2) user_name
+        3) group (person group, user group, or generic group)
+
+        Parameters
+        ----------
+        institution: str, the project from which the group should be
+            unaffiliated
+        group_name: str, the existing group to unaffiliate
+
+        Returns
+        -------
+        dict
+
+        """
+        q = "select project_group_remove('{0}', '{1}')".format(project, group_name)
+        return self.exec_sql(q, session_identity=session_identity, session=session)[0][0]
+
+    def project_groups(
+        self,
+        project: str,
+        session_identity: Optional[str] = None,
+        session: Optional[sqlalchemy.orm.session.Session] = None,
+    ) -> dict:
+        """
+        Get the affiliation graph of project.
+
+        Parameters
+        ----------
+        project: str
+
+        Returns
+        -------
+        dict
+
+        """
+        q = "select project_groups('{0}')".format(project)
         return self.exec_sql(q, session_identity=session_identity, session=session)[0][0]
 
     def capability_grant_rank_set(

--- a/iam/pgiam.py
+++ b/iam/pgiam.py
@@ -767,6 +767,26 @@ class Db(object):
         q = "select project_groups('{0}')".format(project)
         return self.exec_sql(q, session_identity=session_identity, session=session)[0][0]
 
+    def project_institutions(self,
+        project: str,
+        session_identity: Optional[str] = None,
+        session: Optional[sqlalchemy.orm.session.Session] = None,
+    ) -> dict:
+        """
+        Get the institution graph of project.
+
+        Parameters
+        ----------
+        project: str
+
+        Returns
+        -------
+        dict
+
+        """
+        q = "select project_institutions('{0}')".format(institution)
+        return self.exec_sql(q, session_identity=session_identity, session=session)[0][0]
+
     def capability_grant_rank_set(
         self,
         grant_id: str,


### PR DESCRIPTION
Add four project affiliation functions:
- `project_group_add`, affiliate a group to project
- `project_group_remove`, remove affiliation of group to project
- `project_groups`, get affiliation graph of project
- `project_institutions`, get institution graph of project

Add three institution membership functions:
- `institution_member_add`, add member to institution
- `institution_member_remove`, remove member from institution
- `institution_members`, get membership graph of institution

Modify docstring of `institution_group_add`. A correct version of the removed part would be:
```
Note: internally, pg-iam adds groups to instituitions via their [groups']
group.
```
This is obvious so the note is removed.

This pull request should resolve issue [#15](https://github.com/unioslo/pypg-iam/issues/15).